### PR TITLE
11회차

### DIFF
--- a/devappmin/11060.점프 점프.py
+++ b/devappmin/11060.점프 점프.py
@@ -1,0 +1,20 @@
+import sys
+
+n = int(sys.stdin.readline())
+graph = list(map(int, sys.stdin.readline().split()))
+dp = [9999999] * n
+dp[0] = 0
+ans = False
+
+for idx in range(n):
+    for jump in range(1, graph[idx] + 1):
+        if idx + jump >= n:
+            break
+
+        dp[idx + jump] = min(dp[idx + jump], dp[idx] + 1)
+
+    if dp[n - 1] != 9999999:
+        ans = True
+        break
+
+print(-1 if not ans else dp[n - 1])

--- a/devappmin/18108.1998년생인 내가 태국에서는 2541년생?!.py
+++ b/devappmin/18108.1998년생인 내가 태국에서는 2541년생?!.py
@@ -1,0 +1,1 @@
+print(int(input()) - 543)

--- a/devappmin/2502.떡 먹는 호랑이.py
+++ b/devappmin/2502.떡 먹는 호랑이.py
@@ -1,0 +1,36 @@
+import sys
+
+d, k = map(int, sys.stdin.readline().split())
+
+dp = [(1, 0), (0, 1)]
+
+for idx in range(2, d):
+    dp.append((dp[idx - 1][0] + dp[idx - 2][0],
+              dp[idx - 1][1] + dp[idx - 2][1]))
+
+
+def solution():
+    i, j = 0, 0
+    while True:
+        j = 0
+        while True:
+            if dp[d - 1][0] * i + dp[d - 1][1] * j == k:
+                print(i, j, sep='\n')
+                return
+
+            if dp[d - 1][0] * i + dp[d - 1][1] * j > k:
+                break
+            j += 1
+        i += 1
+
+
+solution()
+
+# for i in range(d):
+#     for j in range(d):
+#         if dp[d - 1][0] * i + dp[d - 1][1] * j == k:
+#             print(i, j, sep='\n')
+#             return
+#         if dp[d - 1][0] * i + dp[d - 1][1] * j > k:
+#             break
+# 2 26 28 54 82 136 218 354

--- a/devappmin/2558.A+B - 2.py
+++ b/devappmin/2558.A+B - 2.py
@@ -1,0 +1,1 @@
+print(sum([int(input()) for _ in range(2)]))

--- a/devappmin/2573.빙산.py
+++ b/devappmin/2573.빙산.py
@@ -1,0 +1,98 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+dy, dx = [1, -1, 0, 0], [0, 0, 1, -1]
+
+n, m = map(int, input().split())
+
+matrix = []
+mq = deque()
+ans = 0
+total = 0
+
+for y_idx in range(n):
+    row = list(map(int, input().split()))
+
+    for x_idx in range(m):
+        if row[x_idx] != 0:
+            mq.append((y_idx, x_idx))
+            total += 1
+    
+
+    matrix.append(row)
+
+
+def solution():
+    global total
+    global mq
+    visited = [[0] * m for _ in range(n)]
+    ntotal = 0
+    qq = deque()
+
+    if mq:
+        # ntotal +=1
+        qq.append(mq.popleft())
+
+    while qq:
+
+        y, x = qq.popleft()
+
+        for idx in range(4):
+            ny, nx = y + dy[idx], x + dx[idx]
+
+
+            if not (0 <= ny < n and 0 <= nx < m):
+                continue
+
+            if matrix[ny][nx] == 0:
+                continue
+
+            if visited[ny][nx] != 0:
+                continue
+
+            qq.append((ny, nx))
+            visited[ny][nx] = 1
+            ntotal += 1
+            for i in range(4):
+                nny, nnx = ny + dy[i], nx + dx[i]
+
+                if not(0 <= nny < n and 0 <= nnx < m):
+                    continue
+                
+                if matrix[nny][nnx] != 0:
+                    continue
+
+                visited[ny][nx] += 1
+    
+    
+    if total == 0 or total == 1:
+        global ans
+        ans = 0
+        return False
+
+    if ntotal != total:
+        return False
+
+    mq = deque()
+    total = 0
+
+    for y_idx in range(n):
+        for x_idx in range(m):
+            if visited[y_idx][x_idx] == 0:
+                continue
+
+            matrix[y_idx][x_idx] = max(0, matrix[y_idx][x_idx] - visited[y_idx][x_idx] + 1)
+
+            if matrix[y_idx][x_idx] > 0:
+                mq.append((y_idx, x_idx))
+                total += 1
+
+    return True
+
+
+
+while solution():
+    ans += 1
+
+print(ans)

--- a/devappmin/2573.빙산.py
+++ b/devappmin/2573.빙산.py
@@ -30,17 +30,17 @@ def solution():
     ntotal = 0
     qq = deque()
 
+    # 덩어리의 위치 값이 들어있는 큐에서
+    # 가장 첫번째 값을 뽑아 다른 큐에 넣음
     if mq:
-        # ntotal +=1
         qq.append(mq.popleft())
 
-    while qq:
 
+    while qq:
         y, x = qq.popleft()
 
         for idx in range(4):
             ny, nx = y + dy[idx], x + dx[idx]
-
 
             if not (0 <= ny < n and 0 <= nx < m):
                 continue
@@ -51,9 +51,20 @@ def solution():
             if visited[ny][nx] != 0:
                 continue
 
+            
             qq.append((ny, nx))
+            
+            # 일단 해당 위치를 방문했다는 의미에서
+            # 재방문을 방지하기 위해 1을 넣음.
+            # 이 값은 빙산 matrix를 업데이트할 때
+            # 없앨 예정
             visited[ny][nx] = 1
+            
+            # 검사하면서 얻은 덩어리의 개수를 저장함.
             ntotal += 1
+
+            # 큐에다가 넣을 다음 덩어리의 상하좌우를 검색하여
+            # 0의 개수만큼 visited에 값을 추가함.
             for i in range(4):
                 nny, nnx = ny + dy[i], nx + dx[i]
 
@@ -65,31 +76,43 @@ def solution():
 
                 visited[ny][nx] += 1
     
-    
+    # 0개 혹은 1개의 덩어리가 남았을 경우 답은 0
     if total == 0 or total == 1:
         global ans
         ans = 0
         return False
-
+    
+    # 검사한 덩어리와 총 덩어리의 개수가
+    # 다르면 2개 이상으로 나눠져 있는 의미
     if ntotal != total:
         return False
 
     mq = deque()
     total = 0
 
+    # matrix하고 큐를 새로 업데이트하는 부분
     for y_idx in range(n):
         for x_idx in range(m):
+            # 이미 물인 부분은 넘어감.
             if visited[y_idx][x_idx] == 0:
                 continue
 
+            # 만약에 빙산 부분이면 그 빙산에 visited의 값을 빼고
+            # 아까 방문확인을 위해 1을 뺐으니까 다시 1을 더함
             matrix[y_idx][x_idx] = max(0, matrix[y_idx][x_idx] - visited[y_idx][x_idx] + 1)
 
+            # 그럼에도 불구하고 빙산이 존재하면
+            # 큐에다가 그 값을 삽입하고
+            # 전체 빙산의 개수에 1을 더함
             if matrix[y_idx][x_idx] > 0:
                 mq.append((y_idx, x_idx))
                 total += 1
 
+    # 여기까지 왔다면
+    # 덩어리가 0개도 아니고 1개도 아니고
+    # 두 개로 나눠진 상황도 아니기 때문에
+    # True를 리턴함
     return True
-
 
 
 while solution():

--- a/devappmin/3055.탈출.py
+++ b/devappmin/3055.탈출.py
@@ -1,0 +1,78 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+r, c = map(int, input().split())
+
+dy, dx = [1, -1, 0, 0], [0, 0, 1, -1]
+
+w_matrix = []
+s_matrix = []
+wq = deque()
+sq = deque()
+
+for idx in range(r):
+    row = list(input().rstrip())
+
+    if '*' in row:
+        wq.append((idx, row.index('*')))
+        w_matrix.append([*row])
+        w_matrix[-1][row.index('*')] = 0
+    else:
+        w_matrix.append([*row])
+    
+    if 'S' in row:
+        sq.append((idx, row.index('S')))
+        s_matrix.append([*row])
+        s_matrix[-1][row.index('S')] = 0
+    else:
+        s_matrix.append([*row])
+
+while wq:
+    y, x = wq.popleft()
+
+    for idx in range(4):
+        ny, nx = y + dy[idx], x + dx[idx]
+
+        if not (0 <= ny < r and 0 <= nx < c):
+            continue
+
+        if w_matrix[ny][nx] == 'X' or w_matrix[ny][nx] == 'D':
+            continue
+
+        if type(w_matrix[ny][nx]) == int:
+            continue
+
+        w_matrix[ny][nx] = w_matrix[y][x] + 1
+        wq.append((ny, nx))
+    
+
+while sq:
+    y, x = sq.popleft()
+
+    for idx in range(4):
+        ny, nx = y + dy[idx], x + dx[idx]
+
+        if not (0 <= ny < r and 0 <= nx < c):
+            continue
+
+        if s_matrix[ny][nx] == 'X':
+            continue
+
+        if type(s_matrix[ny][nx]) == int:
+            continue
+        
+        if type(w_matrix[ny][nx]) == int and s_matrix[y][x] + 1 >= w_matrix[ny][nx]:
+            continue
+
+        if s_matrix[ny][nx] == 'D':
+            print(s_matrix[y][x] + 1)
+            exit(0)
+
+        s_matrix[ny][nx] = s_matrix[y][x] + 1
+        sq.append((ny, nx))
+
+print("KAKTUS")
+
+# print(w_matrix)
+# print(s_matrix)

--- a/devappmin/5639.이진 검색 트리.py
+++ b/devappmin/5639.이진 검색 트리.py
@@ -1,0 +1,78 @@
+import sys
+sys.setrecursionlimit(10 ** 6)
+
+nodes = []
+
+while True:
+    try:
+        nodes.append(int(sys.stdin.readline()))
+    except:
+        break
+
+
+def post_order(left_node, right_node):
+    if left_node > right_node:
+        return
+
+    mid_node = right_node + 1
+
+    for idx in range(left_node + 1, right_node + 1):
+        if nodes[left_node] < nodes[idx]:
+            mid_node = idx
+            break
+
+    post_order(left_node + 1, mid_node - 1)
+    post_order(mid_node, right_node)
+    print(nodes[left_node])
+
+
+post_order(0, len(nodes) - 1)
+
+
+# 아래는 불합격한 코드
+# import sys
+
+# nodes = {}
+
+# while True:
+#     try:
+#         node = int(sys.stdin.readline())
+#         if not nodes:
+#             root = node
+#             nodes[root] = ['.', '.']
+#             continue
+
+#         current_pos = root
+
+#         while True:
+#             if current_pos > node:
+#                 if nodes[current_pos][0] == '.':
+#                     nodes[current_pos][0] = node
+#                     nodes[node] = ['.', '.']
+#                     break
+#                 else:
+#                     current_pos = nodes[current_pos][0]
+#             else:
+#                 if nodes[current_pos][1] == '.':
+#                     nodes[current_pos][1] = node
+#                     nodes[node] = ['.', '.']
+#                     break
+#                 else:
+#                     current_pos = nodes[current_pos][1]
+#     except:
+#         break
+
+
+# def post_order(node):
+#     if nodes[node][0] != '.':
+#         post_order(nodes[node][0])
+
+#     if nodes[node][1] != '.':
+#         post_order(nodes[node][1])
+
+#     print(node)
+
+
+# post_order(root)
+
+# # 50 30 24 5 28 45 98 52 60


### PR DESCRIPTION
## 11060 - 점프 점프
### DP

모든 위치를 최대 크기로 맞춰 놓고 `현재 위치`에서 `현재 위치 + 점프 값`까지 이동하면서 최소 값을 구함.

## 2502 - 떡 먹는 호랑이
### DP

첫  번째 값과 두 번째 값이 반복되는 패턴
```python
dp = [(1, 0), (0, 1)]

for idx in range(2, d):
    dp.append((dp[idx - 1][0] + dp[idx - 2][0], dp[idx - 1][1] + dp[idx - 2][1]))
```
위 코드를 통해서 첫 번째 값이 몇 번 들어갔는지, 두 번째 값이 몇 번 들어갔는지를 확인한다.

그 이후에는 `첫 번째 값의 개수 * 배수 + 두 번째 값의 개수 * 배수`가 정답일 때
그 배수의 값을 출력한다.

## 3055 - 탈출
### BFS

불!과 비슷한 형식의 문제.

물을 전부 퍼트린 다음에 고슴도치를 움직여 고슴도치가 이동할 위치가 물이 퍼지는데 걸린 시간과 같거나 더 많이 소요되면 그 쪽으로 못 움직이게 한다.

또한 visited는 해당 matrix에 int로 값을 넣어 타입 검색을 통해 해결했음.

## 5639 - 이진 검색 트리
### Graph Theory

기존에 그래프를 전부 만들어서 움직이는 것은 실패.

전위 순회로 입력이 되어있으므로 지금 위치의 값보다 더 큰 값이 나온 경우는 자신의 오른쪽 노드에 해당하는 것임.

또한 그러면 왼쪽 노드와 오른쪽 노드를 다시 재귀로 검색을 하여 마지막에 노드를 출력하면 후위 순회임.

고로 예제인 `50 30 24 5 28 45 98 52 60`를 살펴보자면 `50`을 기준으로 `30 24 5 28 45`는 왼쪽 노드, `98 52 60`은 오른쪽 노드임.

이 값을 넣어서 다시 재귀를 하면 `30`의 왼쪽 노드는 `24 5 28` 오른쪽 노드는 `45`임.

이를 반복하고 왼쪽 재귀 오른쪽 재귀를 끝내면 출력하면 됨.

## 2573 - 빙산
### BFS

BFS를 검색할 때 visited의 값을 이동할 노드의 상하좌우 값 중 0의 개수로 함.

또한 BFS를 끝내고 왔더니 총 빙산의 개수와 일치하지 않으면 두 덩어리 이상으로 떨어진 것이므로 더 이상 BFS를 돌리지 않음.
