### PR TITLE
2회차

### DIFF
--- a/Mootata/35회차/1091.카드 섞기.py
+++ b/Mootata/35회차/1091.카드 섞기.py
@@ -1,0 +1,37 @@
+n = int(input())
+p = list(map(int, input().split()))  # 각 카드가 어떤 플레이어에게 가야하는지
+s = list(map(int, input().split()))  # 카드를 섞는 방법
+cards = {}
+answer = 0
+
+for i in range(n):
+    cards[i] = i % 3  # 세사람에게 돌아가면서 카드를 줘야함
+
+first = cards  # 맨 처음 카드를 나눠준 순서
+
+while True:
+    if list(cards.values()) == p:
+        print(answer)
+        break
+
+    temp = {}
+
+    for idx, i in enumerate(s):  # s에 따라 카드 섞음
+        temp[idx] = cards[i]
+
+    if temp == first:  # 맨 처음 카드를 나눠준 순서와 동일하다면, 루프가 존재한다는 의미
+        print(-1)
+        break
+
+    cards = temp
+    answer += 1
+
+
+# A B C
+# C A B
+# B C A
+#
+# 0 1 2
+# 2 0 1
+# 1 2 0
+# 0 1 2

--- a/Mootata/35회차/1106.호텔.py
+++ b/Mootata/35회차/1106.호텔.py
@@ -1,0 +1,15 @@
+c, n = map(int, input().split())  # C명 늘려야 함, 도시의 수
+city = [list(map(int, input().split())) for _ in range(n)]
+dp = [
+    float("inf") for _ in range(c + 100)
+]  # 인덱스는 고객의 수 값은 비용, 한번의 홍보로 최대 100명까지 얻을 수 있음
+dp[0] = 0
+
+for cost, count in city:
+    for i in range(count, c + 100):
+        dp[i] = min(dp[i - count] + cost, dp[i])
+        # i명을 얻는데 드는 비용과
+        # i - count명 까지 얻는데 계산된 최소 비용 + 현재 count명을 얻는데 드는 비용
+        # 두 값을 비교하여 더 작은 비용을 dp[i]에 넣음
+
+print(min(dp[c:]))

--- a/Mootata/35회차/1189.컴백홈.py
+++ b/Mootata/35회차/1189.컴백홈.py
@@ -1,0 +1,32 @@
+dx, dy = [-1, 1, 0, 0], [0, 0, -1, 1]
+
+r, c, k = map(int, input().split())
+board = [list(input()) for _ in range(r)]
+answer = 0
+
+
+def dfs(x, y, dist):
+    global answer
+
+    if (x, y) == (0, c - 1) and dist == k:
+        answer += 1
+        return
+
+    for i in range(4):
+        nx, ny = x + dx[i], y + dy[i]
+
+        if nx < 0 or ny < 0 or nx >= r or ny >= c or board[nx][ny] == "T":
+            continue
+
+        board[nx][ny] = "T"
+        dfs(nx, ny, dist + 1)
+        board[nx][ny] = "."
+
+
+board[r - 1][0] = "T"
+dfs(r - 1, 0, 1)
+print(answer)
+
+# 1트 BFS로 했다가 방문처리 때문에 DFS로 변경
+# 2트 방문처리를 visited로 했는데 그러면 모든 경우는 확인할 수 없음
+# 3트 편의를 위해 (0, 0)에서 (r - 1, c - 1)로 가는 경로를 구했으나, (r - 1, c - 1)가 T일 수 있다는 것을 깜빡함

--- a/Mootata/35회차/1327.소트 게임.py
+++ b/Mootata/35회차/1327.소트 게임.py
@@ -1,0 +1,29 @@
+from collections import deque, defaultdict
+
+n, k = map(int, input().split())
+per = tuple(map(int, input().split()))
+s = tuple(sorted(per))
+visited = defaultdict(bool)
+
+
+def bfs():
+    q = deque([(per, 0)])
+
+    while q:
+        p, count = q.popleft()
+        visited[p] = True
+        if p == s:
+            return count
+
+        for i in range((n + 1) - k):
+            np = p[:i] + tuple(reversed(p[i : i + k])) + p[i + k :]
+
+            if visited[np]:
+                continue
+            q.append((np, count + 1))
+            visited[np] = True
+
+    return -1
+
+
+print(bfs())

--- a/Mootata/35회차/1986.체스.py
+++ b/Mootata/35회차/1986.체스.py
@@ -1,0 +1,139 @@
+n, m = map(int, input().split())
+board = [[True for _ in range(m)] for _ in range(n)]
+q = list(map(int, input().split()))
+k = list(map(int, input().split()))
+p = list(map(int, input().split()))
+answer = 0
+
+
+def k_check(x, y):
+    for i, j in [
+        (-1, -2),
+        (-2, -1),
+        (-2, 1),
+        (-1, 2),
+        (1, 2),
+        (2, 1),
+        (2, -1),
+        (1, -2),
+    ]:
+        nx, ny = x + i, y + j
+
+        if (
+            nx < 0
+            or ny < 0
+            or nx >= n
+            or ny >= m
+            or board[nx][ny] == "P"
+            or board[nx][ny] == "K"
+        ):
+            continue
+
+        board[nx][ny] = False
+
+
+def q_check(x, y):
+    board[x][y] = False
+
+    for i in range(1, max(n, m)):  # 오른쪽 아래 대각선
+        nx, ny = x + i, y + i
+        if (
+            nx < 0
+            or ny < 0
+            or nx >= n
+            or ny >= m
+            or board[nx][ny] == "P"
+            or board[nx][ny] == "K"
+        ):
+            break
+
+        board[nx][ny] = False
+
+    for i in range(1, max(n, m)):  # 왼쪽 아래 대각선
+        nx, ny = x + i, y - i
+        if (
+            nx < 0
+            or ny < 0
+            or nx >= n
+            or ny >= m
+            or board[nx][ny] == "P"
+            or board[nx][ny] == "K"
+        ):
+            break
+
+        board[nx][ny] = False
+
+    for i in range(1, max(n, m)):  # 오른쪽 위 대각선
+        nx, ny = x - i, y + i
+        if (
+            nx < 0
+            or ny < 0
+            or nx >= n
+            or ny >= m
+            or board[nx][ny] == "P"
+            or board[nx][ny] == "K"
+        ):
+            break
+
+        board[nx][ny] = False
+
+    for i in range(1, max(n, m)):  # 왼쪽 위 대각선
+        nx, ny = x - i, y - i
+        if (
+            nx < 0
+            or ny < 0
+            or nx >= n
+            or ny >= m
+            or board[nx][ny] == "P"
+            or board[nx][ny] == "K"
+        ):
+            break
+
+        board[nx][ny] = False
+
+    for i in range(1, n):  # 위
+        nx = x - i
+        if nx < 0 or board[nx][y] == "P" or board[nx][y] == "K":
+            break
+
+        board[nx][y] = False
+
+    for i in range(1, n):  # 아래
+        nx = x + i
+        if nx >= n or board[nx][y] == "P" or board[nx][y] == "K":
+            break
+
+        board[nx][y] = False
+
+    for i in range(1, max(n, m)):  # 왼쪽
+        ny = y - i
+        if ny < 0 or board[x][ny] == "P" or board[x][ny] == "K":
+            break
+
+        board[x][ny] = False
+
+    for i in range(1, max(n, m)):  # 오른쪽
+        ny = y + i
+        if ny >= m or board[x][ny] == "P" or board[x][ny] == "K":
+            break
+
+        board[x][ny] = False
+
+
+for i in range(1, p[0] + 1):
+    board[p[(i * 2) - 1] - 1][p[(i * 2)] - 1] = "P"
+
+for i in range(1, k[0] + 1):
+    x, y = k[(i * 2) - 1] - 1, k[(i * 2)] - 1
+    board[x][y] = "K"
+    k_check(x, y)
+
+for i in range(1, q[0] + 1):
+    x, y = q[(i * 2) - 1] - 1, q[(i * 2)] - 1
+    board[x][y] = "Q"
+    q_check(x, y)
+
+for i in board:
+    answer += i.count(True)
+
+print(answer)


### PR DESCRIPTION
## 1091.카드섞기
구현 문제, 딕셔너리를 이용해서 풀었음.  
카드를 섞고나서 처음 상태와 같다면, 루프가 존재한다는 의미이므로 -1 출력  

## 1106.호텔
DP 문제, dp 인덱스는 고객의 수, 값은 해당 고객 수를 모으는데 계산된 최소 비용  

## 1189.컴백홈
DFS로 풀었음, visited로 방문처리를 하면, 모든 경우를 확인할 수 없어서 board 리스트에 직접 체크  

## 1327.소트 게임
구현 문제, BFS로 풀었고, 파이썬의 리스트 슬라이싱을 활용했음.  
처음엔 visited 방문처리를 set으로 구현했으나, 메모리 초과로 defaultdict로 변경 후 통과  

## 1986.체스
구현 문제, 문제에서 제시된 조건과 동일하게 이동을 구현했음.  
board에 True, False 값을 통해 방문 체크 후 True의 수를 체크하여 출력